### PR TITLE
inform newly created teams they might need to accept an invitation

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ controller.hears(['create team'], ['direct_message', 'direct_mention'], function
     jarvis.createTeam(convo, function(){
       jarvis.addTeamMembers(convo, function(){
         jarvis.createContent(convo, function(url){
-          convo.say(`Ok, we’re all set. The team can get started at https://github.com/${process.env.GITHUB_ORGANIZATION}/${jarvis.team.name}`);
+          convo.say(`Ok, we’re all set. You may have an email waiting for you. After joining the organization, you can get started at https://github.com/${process.env.GITHUB_ORGANIZATION}/${jarvis.team.name}`);
           convo.next();
         });
       });


### PR DESCRIPTION
some folks are assuming they can just click and go based on this message, actually they might need to accept an invitation to join the organization before they explicitly have permission to view the new private repository

so, if you just click the link the 404 is expected (you don't have permission to see a private repo) but the expectation hasn't been set with the user :wink:
