### PR TITLE
allow members added to teams the ability to maintain the team itself

### DIFF
--- a/jarvis.js
+++ b/jarvis.js
@@ -90,7 +90,7 @@ class Jarvis {
             return new Promise(function(resolve, reject){
               github.orgs.addTeamMembership({
                 id: me.team.id,
-                user: member
+                user: maintainer
               }, function(err, data){
                 if(err){
                   return reject(`Uh oh, we couldn't add ${member}.`);


### PR DESCRIPTION
this way users that are added have their own permission and abilities to add or remove team members themselves

> maintainer - a team maintainer. Able to add/remove other team members, promote other team members to team maintainer, and edit the team's name and description.

https://developer.github.com/v3/orgs/teams/#add-team-membership
