### PR TITLE
Adding some more help text

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ controller.hears(['create team'], ['direct_message', 'direct_mention'], function
     jarvis.createTeam(convo, function(){
       jarvis.addTeamMembers(convo, function(){
         jarvis.createContent(convo, function(url){
-          convo.say(`Ok, we’re all set. You may have an email waiting for you. After joining the organization, you can get started at https://github.com/${process.env.GITHUB_ORGANIZATION}/${jarvis.team.name}`);
+          convo.say(`Ok, we’re all set. You have an invitation email waiting for you. You can also visit https://github.com/${process.env.GITHUB_ORGANIZATION} and click the "View Invitation" button at the top.`);
+          convo.say(`After accepting your invitation you can get started at: https://github.com/${process.env.GITHUB_ORGANIZATION}/${jarvis.team.name}`);
           convo.next();
         });
       });

--- a/jarvis.js
+++ b/jarvis.js
@@ -13,7 +13,8 @@ class Jarvis {
     var github = this.github;
     var me = this;
 
-    convo.ask('What’s the team’s name?', [{
+    convo.say('OK! Let\'s get started. But first, make sure everyone on your team already has a GitHub.com user account (or stop now and come back when they do).')
+    convo.ask('Ready? What’s your team’s name? No spaces or hyphens, please.', [{
       pattern: /^[a-z0-9]+$/i,
       callback: function(response, convo) {
 

--- a/jarvis.js
+++ b/jarvis.js
@@ -63,7 +63,7 @@ class Jarvis {
     var github = this.github;
     var me = this;
 
-    convo.ask('Who would you like to add to the team? (Comma-separated list of GitHub usernames)', function(response, convo){
+    convo.ask('Who would you like to add to your team? (this should be a comma-separated list of all your team member\'s GitHub usernames, yourself included, and please do not include the @-sign)', function(response, convo){
 
       var teamMembers = response.text.split(/[\s,]+/);
       var printableTeamMembers = teamMembers.slice(0, teamMembers.length-1).join(', ') + ' and ' + teamMembers[teamMembers.length-1];


### PR DESCRIPTION
@homeyer Both @margaretrms and I worked on some minor text changes to make instructions clearer and hopefully cut down on user error or confusion when getting set up (less support needs).

Three things here:

- try to get folks to know all team members before team creation
- explain gotchas of adding team members
- explain the invitation process and how it has to be accepted first